### PR TITLE
Add dynamic discussion forum URL to guide navigation and update guide…

### DIFF
--- a/module/layouts/_partials/components/guide/render-guide.html
+++ b/module/layouts/_partials/components/guide/render-guide.html
@@ -5,7 +5,22 @@
     <aside class="col-md-3" style="top: 1rem; max-height: 100vh;" aria-label="Table of contents navigation">
       <nav class="content-list bg-light p-3 rounded h-100 d-flex flex-column" aria-label="Guide navigation">
         <div class="content-collaboration d-flex justify-content-between align-items-center mb-3 pb-2 border-bottom">
-          <a href="{{ .Site.Params.githubUrl }}/discussions" class="text-decoration-none text-primary" target="_blank"> <i class="fa-solid fa-comments me-1"></i>{{ i18n "guide_join_discussion" }} </a>
+          {{- $sectionPage := .Site.GetPage .Section }}
+          {{- $discussionUrl := .Site.Params.githubUrl | default "" }}
+          {{- if $sectionPage }}
+            {{- if $sectionPage.Params.discussionForumUrl }}
+              {{- $discussionUrl = $sectionPage.Params.discussionForumUrl }}
+            {{- else }}
+              {{- $discussionUrl = printf "%s/discussions" (.Site.Params.githubUrl | default "") }}
+            {{- end }}
+          {{- else }}
+            {{- /* Fallback: use default GitHub discussions URL if section page not found */}}
+            {{- $discussionUrl = printf "%s/discussions" (.Site.Params.githubUrl | default "") }}
+            {{- warnf "Section page not found for section '%s', using default discussion URL" .Section }}
+          {{- end }}
+          <a href="{{ $discussionUrl }}" class="text-decoration-none text-primary" target="_blank">
+            <i class="fa-solid fa-comments me-1"></i>{{ i18n "guide_join_discussion" }}
+          </a>
           {{ partial "components/share-dropdown.html" . }}
         </div>
 

--- a/site/content/Guide1/_index.md
+++ b/site/content/Guide1/_index.md
@@ -11,6 +11,7 @@ guide_overview: |
   [Guide 1](/guide-1/latest) is a practical, community-curated reference for best practices in knowledge work.
 guide_logo: "guide-1-logo.png"
 weight: 1
+discussionForumUrl: "https://forum.example.com/c/guide-1"
 guide_license: |
   This work is licensed by Generic Publishing Corp and Anonymous Authors under a Creative Commons Attribution 4.0 International License.
 guide_comparison:


### PR DESCRIPTION
This pull request enhances the handling of discussion forum URLs in the guide layout and adds a custom discussion forum URL for "Guide 1." The changes ensure greater flexibility and robustness when linking to discussion forums.

### Improvements to discussion forum URL handling:

* [`module/layouts/_partials/components/guide/render-guide.html`](diffhunk://#diff-f21f473e622a731bb6e2e2f84d3f9b8fc0bf9953a44738657553ee9fa09ebc0aL8-R23): Updated the logic to dynamically determine the discussion forum URL based on the section page's parameters. If no specific URL is provided, a default GitHub discussions URL is used, with a fallback and warning if the section page is not found.

### Content updates:

* [`site/content/Guide1/_index.md`](diffhunk://#diff-adfeed81fe63845a67da14c3a521a7608aec4101f9e90521ebc76b33c38ca678R14): Added a custom `discussionForumUrl` parameter for "Guide 1," pointing to an external forum URL.… metadata