### PR TITLE
Fix spacing in guide version dropdown for better readability

### DIFF
--- a/module/layouts/_partials/components/guide/guide-version-select.html
+++ b/module/layouts/_partials/components/guide/guide-version-select.html
@@ -12,7 +12,7 @@
 {{- if gt (len $allVersions) 1 }}
   <div class="dropdown d-inline-block">
     <button class="btn btn-outline-secondary btn-sm dropdown-toggle version-dropdown" type="button" data-bs-toggle="dropdown" aria-expanded="false" aria-label="{{ i18n "guide_version_dropdown_label" }}">
-      v{{ $currentVersion }}{{- if $isOnLatest }}({{ i18n "guide_version_latest" }}){{- end }}
+      v{{ $currentVersion }}{{- if $isOnLatest }}&nbsp;({{ i18n "guide_version_latest" | default "latest" }}){{- end }}
     </button>
     <ul class="dropdown-menu">
       {{- range $allVersions }}
@@ -20,14 +20,14 @@
         {{- if $isCurrent }}
           <li>
             <span class="dropdown-item active" aria-current="page">
-              v{{ .version }}{{- if .isLatest }}({{ i18n "guide_version_latest" }}){{- end }} -
-              {{ i18n "guide_version_current" }}
+              v{{ .version }}{{- if .isLatest }}&nbsp;({{ i18n "guide_version_latest" | default "latest" }}){{- end }} -
+              {{ i18n "guide_version_current" | default "current" }}
             </span>
           </li>
         {{- else }}
           <li>
             <a class="dropdown-item" href="{{ .url }}">
-              v{{ .version }}{{- if .isLatest }}({{ i18n "guide_version_latest" }}){{- end }}
+              v{{ .version }}{{- if .isLatest }}&nbsp;({{ i18n "guide_version_latest" | default "latest" }}){{- end }}
             </a>
           </li>
         {{- end }}
@@ -35,7 +35,7 @@
     </ul>
   </div>
 {{- else }}
-  <span class="version-number">v{{ $currentVersion }}{{- if $isOnLatest }}({{ i18n "guide_version_latest" }}){{- end }}</span>
+  <span class="version-number">v{{ $currentVersion }}{{- if $isOnLatest }}&nbsp;({{ i18n "guide_version_latest" | default "latest" }}){{- end }}</span>
 {{- end }}
 
 


### PR DESCRIPTION
This pull request updates the `guide-version-select.html` file to improve the handling of default values for internationalised strings and ensure consistent formatting in the version dropdown.

### Improvements to internationalisation and formatting:

* Added the `default` function to provide fallback values for the `i18n` keys `guide_version_latest` and `guide_version_current`, ensuring proper defaults ("latest" and "current") are displayed when translations are unavailable. (`[module/layouts/_partials/components/guide/guide-version-select.htmlL15-R38](diffhunk://#diff-c404c24e2469819d871a8b512b23fec7c8517a971c91017d8f568f621135d913L15-R38)`)
* Replaced inline parentheses with a non-breaking space (`&nbsp;`) before the parentheses for better visual spacing and formatting consistency in the version dropdown and version display. (`[module/layouts/_partials/components/guide/guide-version-select.htmlL15-R38](diffhunk://#diff-c404c24e2469819d871a8b512b23fec7c8517a971c91017d8f568f621135d913L15-R38)`)