### PR TITLE
New i18n bits

### DIFF
--- a/module/layouts/_partials/components/guide/guide-version-notice.html
+++ b/module/layouts/_partials/components/guide/guide-version-notice.html
@@ -15,9 +15,9 @@
           <div class="d-flex align-items-start">
             <i class="fa-solid fa-info-circle me-2 mt-1 flex-shrink-0"></i>
             <div>
-              <strong>Historical Version Notice:</strong>
-              You are viewing version {{ $currentVersion }} of this guide.
-              <a href="{{ $sectionPage.RelPermalink }}" class="alert-link"> View the latest version ({{ $latestVersion }}) </a> for the most up-to-date information.
+              <strong>{{ i18n "guide_historical_version_notice_title" }}</strong>
+              {{ i18n "guide_historical_version_notice_text" (dict "CurrentVersion" $currentVersion) }}
+              <a href="{{ $sectionPage.RelPermalink }}" class="alert-link">{{ i18n "guide_historical_version_notice_link" (dict "LatestVersion" $latestVersion) }}</a> {{ i18n "guide_historical_version_notice_suffix" }}
             </div>
           </div>
         </div>

--- a/module/layouts/_partials/components/guide/render-guide.html
+++ b/module/layouts/_partials/components/guide/render-guide.html
@@ -175,7 +175,7 @@
             <!-- Authors from creators list -->
 
             <div class="content-version mt-2">
-              <span class="text-muted">{{ i18n "guide_version_label" . }} </span>
+              <span class="text-muted">{{ i18n "guide_version_label" . }} </span>&nbsp;
               {{ partial "components/guide/guide-version-select.html" . }}
             </div>
           </header>

--- a/site/i18n/en.yaml
+++ b/site/i18n/en.yaml
@@ -297,6 +297,18 @@
 - id: guide_version_latest
   translation: "Latest"
 
+- id: guide_historical_version_notice_title
+  translation: "Historical Version Notice:"
+
+- id: guide_historical_version_notice_text
+  translation: "You are viewing version {{ .CurrentVersion }} of this guide."
+
+- id: guide_historical_version_notice_link
+  translation: "View the latest version ({{ .LatestVersion }})"
+
+- id: guide_historical_version_notice_suffix
+  translation: "for the most up-to-date information."
+
 - id: guide_content_unavailable_note
   translation: "Note:"
 

--- a/site/i18n/min.yaml
+++ b/site/i18n/min.yaml
@@ -291,6 +291,18 @@
 - id: guide_version_latest
   translation: "Fresh Banana"
 
+- id: guide_historical_version_notice_title
+  translation: "Old Banana Alert:"
+
+- id: guide_historical_version_notice_text
+  translation: "You looky at banana version {{ .CurrentVersion }} of dis guide."
+
+- id: guide_historical_version_notice_link
+  translation: "See da fresh banana ({{ .LatestVersion }})"
+
+- id: guide_historical_version_notice_suffix
+  translation: "for da newest banana info."
+
 - id: guide_content_unavailable_note
   translation: "Banana Note:"
 


### PR DESCRIPTION
This pull request introduces internationalization (i18n) for the historical version notice in the guide layout. The changes replace hardcoded text with translatable strings and add corresponding translations for English and Minion languages. Additionally, a minor formatting adjustment was made in the guide version display.

### Internationalization of Historical Version Notice:

* [`module/layouts/_partials/components/guide/guide-version-notice.html`](diffhunk://#diff-6ae53c9075674ce3f49dd787fd9fc3722d5bbf01cb2e3df5a705cdd6ef6b1edaL18-R20): Replaced hardcoded historical version notice text with i18n strings, including title, main text, link, and suffix.
* [`site/i18n/en.yaml`](diffhunk://#diff-edf3e5566d707f973c44aac01937c9f60bd149c08df4495aebe2d77bc1ffb494R300-R311): Added English translations for the historical version notice title, text, link, and suffix.
* [`site/i18n/min.yaml`](diffhunk://#diff-128feb86e84a72ad99bff65ed6609d07a09cdbd12cda620f8e25c06aa076c5c8R294-R305): Added Minion-language translations for the historical version notice title, text, link, and suffix.

### Minor Formatting Adjustment:

* [`module/layouts/_partials/components/guide/render-guide.html`](diffhunk://#diff-f21f473e622a731bb6e2e2f84d3f9b8fc0bf9953a44738657553ee9fa09ebc0aL178-R178): Added a non-breaking space (`&nbsp;`) after the guide version label for improved spacing.